### PR TITLE
Fix "Advance Theming with Sencha Fashion" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ### Presentations
 - [Material Design for ExtJS](https://speakerdeck.com/steffenhiller/materializing-ext-js) by @steffen
-- [Advance Theming with Sencha Fashion](https://speakerdeck.com/steffenhiller/materializing-ext-js) by @ladysign
+- [Advance Theming with Sencha Fashion](https://speakerdeck.com/savelee/advance-theming-with-sencha-fashion) by @ladysign
 - [SenchaCon Roadshow 2015 - Sencha Ext JS 6](http://www.slideshare.net/stoe288/sencha-ext-js-6) by @stoe288
 - [Smaller is better](http://www.slideshare.net/stoe288/senchacon-roadshow-2015-smaller-is-better) by @stoe288
 - [Deploying and Managing Applications with Sencha Space](http://www.slideshare.net/stoe288/senchacon-roadshow-2015-view-models-and-binding) by @stoe288


### PR DESCRIPTION
Hi, and thank you for creating this repository.

This pull request fixes the "Advance Theming with Sencha Fashion" link which redirected to the previous presentation in the list ("Material Design for ExtJS") instead of the actual presentation.
